### PR TITLE
Prevent arbitrary code exec through XSS in document.referrer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ var/
 *.swp
 bin/
 typescript
+.vscode
 
 # macOS specific stuff
 .DS_Store

--- a/src/js/error.js
+++ b/src/js/error.js
@@ -1,2 +1,11 @@
 // Configure the Back button href
-$(".card a.btn").attr("href", document.referrer);
+const sanitizeUrl = (url) => {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin + parsed.pathname;
+  } catch (e) {
+    return '/';
+  }
+};
+
+$(".card a.btn").attr("href", sanitizeUrl(document.referrer));

--- a/src/js/error.js
+++ b/src/js/error.js
@@ -1,11 +1,19 @@
-// Configure the Back button href
-const sanitizeUrl = (url) => {
-  try {
-    const parsed = new URL(url);
-    return parsed.origin + parsed.pathname;
-  } catch (e) {
-    return '/';
-  }
-};
-
-$(".card a.btn").attr("href", sanitizeUrl(document.referrer));
+try {
+    const referrer = document.referrer;
+    if (referrer) {
+        const referrerUrl = new URL(referrer);
+        const currentOrigin = window.location.origin;
+        // Only allow same-origin referrers and only those with http/https
+        if ((referrerUrl.protocol === 'http:' || referrerUrl.protocol === 'https:')
+            && referrerUrl.origin === currentOrigin) {
+            $(".card a.btn").attr("href", referrer);
+        } else {
+            $(".card a.btn").attr("href", '/');
+        }
+    } else {
+        $(".card a.btn").attr("href", '/');
+    }
+} catch (ex) {
+    // Invalid URL: use safe fallback of /
+    $(".card a.btn").attr("href", '/');
+}

--- a/src/js/error.js
+++ b/src/js/error.js
@@ -2,7 +2,7 @@ try {
     const referrer = document.referrer;
     if (referrer) {
         const referrerUrl = new URL(referrer);
-        const currentOrigin = window.location.origin;
+        const currentOrigin = globalThis.location.origin;
         // Only allow same-origin referrers and only those with http/https
         if ((referrerUrl.protocol === 'http:' || referrerUrl.protocol === 'https:')
             && referrerUrl.origin === currentOrigin) {
@@ -13,7 +13,7 @@ try {
     } else {
         $(".card a.btn").attr("href", '/');
     }
-} catch (ex) {
+} catch {
     // Invalid URL: use safe fallback of /
     $(".card a.btn").attr("href", '/');
 }


### PR DESCRIPTION
## 🗒️ Summary

Merge this to [make SonarQube Cloud](https://sonarcloud.io/project/issues?open=AZPV2bewMno7aLBoeiiH&id=NASA-PDS_s3-browser-cloudfront) happy with regard to an arbitrary code execution in:

    $(".card a.btn").attr("href", document.referrer);

where an XSS vulnerability exists by referencing the untrusted `document.referrer`. The HTTP `Referer` [sic] header can be arbitrarily set and allows for an XSS attack. For a proof-of-concept, set the `Referer` [sic] header to `javascript:alert('hello')` and get a "hello" modal in your browser.

The fix in 94c000c089815c1a597433f1ea1ef2fbae67d90e is a good start! This goes a step further by also limiting referrers to `http` and `https` protocols (avoiding `javascript:`, `vbscript:`, etc.).


## ⚙️ Test Data and/or Report

SonarQube gives a green light: https://sonarcloud.io/dashboard?id=NASA-PDS_s3-browser-cloudfront&pullRequest=137

## ♻️ Related Issues

- #136 

